### PR TITLE
Add unit tests for `UIView+Inspecting` #25

### DIFF
--- a/UnIt/Source/CGFloat+Precision.swift
+++ b/UnIt/Source/CGFloat+Precision.swift
@@ -1,6 +1,8 @@
 public extension CGFloat {
     func roundTo(decimalPlace: Int) -> CGFloat {
-        let divisor = CGFloat(10 ^ decimalPlace)
-        return (self * divisor).rounded() / divisor
+        let divisor = CGFloat(truncating: (NSDecimalNumber(decimal: pow(10, decimalPlace))))
+        return (self * divisor)
+            .rounded(.toNearestOrAwayFromZero)
+            / divisor
     }
 }

--- a/UnIt/Source/CGSize+Comparing.swift
+++ b/UnIt/Source/CGSize+Comparing.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension CGSize {
-    func isEquivalentTo(otherSize: CGSize, precision: Int = 2) -> Bool {
+    func isEqualTo(otherSize: CGSize, precision: Int = 2) -> Bool {
         let isEqualWidth = self.width.roundTo(decimalPlace: precision) == otherSize.width.roundTo(decimalPlace: precision)
         let isEqualHeight = self.height.roundTo(decimalPlace: precision) == otherSize.height.roundTo(decimalPlace: precision)
         return isEqualWidth && isEqualHeight

--- a/UnIt/Source/CGSize+Comparing.swift
+++ b/UnIt/Source/CGSize+Comparing.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension CGSize {
-    func isEqualTo(otherSize: CGSize, precision: Int = 2) -> Bool {
+    func isRoughlyEqualTo(otherSize: CGSize, precision: Int = 2) -> Bool {
         let isEqualWidth = self.width.roundTo(decimalPlace: precision) == otherSize.width.roundTo(decimalPlace: precision)
         let isEqualHeight = self.height.roundTo(decimalPlace: precision) == otherSize.height.roundTo(decimalPlace: precision)
         return isEqualWidth && isEqualHeight

--- a/UnIt/Source/Device.swift
+++ b/UnIt/Source/Device.swift
@@ -17,7 +17,7 @@ public enum Device {
     case iPhoneXS
     case iPhoneXSMax
     
-    var dimensions: (screensize: CGSize, scaleFactor: CGFloat) {
+    public var dimensions: (screensize: CGSize, scaleFactor: CGFloat) {
         switch self {
         case .iPhoneSE:
             return (CGSize(width: 320, height: 568), 2.0)

--- a/UnIt/Source/UIView+Inspecting.swift
+++ b/UnIt/Source/UIView+Inspecting.swift
@@ -6,13 +6,11 @@ public extension UIView {
      - Note: Taken from an Objective-C library called PivotalCoreKit: https://github.com/pivotal-legacy/PivotalCoreKit/blob/master/UIKit/SpecHelper/Extensions/UIControl%2BSpec.m
      */
     var isTrulyVisible: Bool {
-        if isHidden {
-            return false
-        }
-        if alpha == 0 {
-            return false
-        }
-        if frame.size.width == 0 || frame.size.height == 0 {
+        if
+            isHidden ||
+            alpha == 0 ||
+            frame.size.width == 0 ||
+            frame.size.height == 0 {
             return false
         }
         if let superview = self.superview {
@@ -32,7 +30,7 @@ public extension UIView {
         return bounds.size.isRoughlyEqualTo(otherSize: otherView.bounds.size)
     }
     
-    func isSizeRoughlyEqualTo(_ rect: CGRect, precision: Int = 2) -> Bool {
+    func isSizeRoughlyEqualTo(rect: CGRect, precision: Int = 2) -> Bool {
         return bounds.size.isRoughlyEqualTo(otherSize: rect.size)
     }
 }

--- a/UnIt/Source/UIView+Inspecting.swift
+++ b/UnIt/Source/UIView+Inspecting.swift
@@ -29,10 +29,10 @@ public extension UIView {
      - returns: A true/false on whether the 2 sizes are equivalent up to 2 decimal places.
      */
     func isEquivalentSizeTo(otherView: UIView, precision: Int = 2) -> Bool {
-        return bounds.size.isEquivalentTo(otherSize: otherView.bounds.size)
+        return bounds.size.isEqualTo(otherSize: otherView.bounds.size)
     }
     
     func isEquivalentSizeTo(_ rect: CGRect, precision: Int = 2) -> Bool {
-        return bounds.size.isEquivalentTo(otherSize: rect.size)
+        return bounds.size.isEqualTo(otherSize: rect.size)
     }
 }

--- a/UnIt/Source/UIView+Inspecting.swift
+++ b/UnIt/Source/UIView+Inspecting.swift
@@ -29,10 +29,10 @@ public extension UIView {
      - returns: A true/false on whether the 2 sizes are equivalent up to 2 decimal places.
      */
     func isEquivalentSizeTo(otherView: UIView, precision: Int = 2) -> Bool {
-        return bounds.size.isEqualTo(otherSize: otherView.bounds.size)
+        return bounds.size.isRoughlyEqualTo(otherSize: otherView.bounds.size)
     }
     
     func isEquivalentSizeTo(_ rect: CGRect, precision: Int = 2) -> Bool {
-        return bounds.size.isEqualTo(otherSize: rect.size)
+        return bounds.size.isRoughlyEqualTo(otherSize: rect.size)
     }
 }

--- a/UnIt/Source/UIView+Inspecting.swift
+++ b/UnIt/Source/UIView+Inspecting.swift
@@ -28,11 +28,11 @@ public extension UIView {
      - secondSize: a **CGSize** of the second view.
      - returns: A true/false on whether the 2 sizes are equivalent up to 2 decimal places.
      */
-    func isEquivalentSizeTo(otherView: UIView, precision: Int = 2) -> Bool {
+    func isSizeRoughlyEqualTo(otherView: UIView, precision: Int = 2) -> Bool {
         return bounds.size.isRoughlyEqualTo(otherSize: otherView.bounds.size)
     }
     
-    func isEquivalentSizeTo(_ rect: CGRect, precision: Int = 2) -> Bool {
+    func isSizeRoughlyEqualTo(_ rect: CGRect, precision: Int = 2) -> Bool {
         return bounds.size.isRoughlyEqualTo(otherSize: rect.size)
     }
 }

--- a/UnIt/Source/UIView+SubviewBounding.swift
+++ b/UnIt/Source/UIView+SubviewBounding.swift
@@ -10,7 +10,7 @@ public extension UIView {
     func subviewsOutOfBounds() -> [UIView] {
         return views(ofType: UIView.self) { subview in
             let rect = self.findOverlappedArea(with: subview)
-            return !subview.isSizeRoughlyEqualTo(rect)
+            return !subview.isSizeRoughlyEqualTo(rect: rect)
         }
     }
     
@@ -22,7 +22,7 @@ public extension UIView {
         return views(ofType: UIView.self) { subview in
             let rect = self.findOverlappedArea(with: subview)
             return self != subview &&
-                subview.isSizeRoughlyEqualTo(rect) && rect.size != CGSize.zero
+                subview.isSizeRoughlyEqualTo(rect: rect) && rect.size != CGSize.zero
         }
     }
     

--- a/UnIt/Source/UIView+SubviewBounding.swift
+++ b/UnIt/Source/UIView+SubviewBounding.swift
@@ -10,7 +10,7 @@ public extension UIView {
     func subviewsOutOfBounds() -> [UIView] {
         return views(ofType: UIView.self) { subview in
             let rect = self.findOverlappedArea(with: subview)
-            return !subview.isEquivalentSizeTo(rect)
+            return !subview.isSizeRoughlyEqualTo(rect)
         }
     }
     
@@ -22,7 +22,7 @@ public extension UIView {
         return views(ofType: UIView.self) { subview in
             let rect = self.findOverlappedArea(with: subview)
             return self != subview &&
-                subview.isEquivalentSizeTo(rect) && rect.size != CGSize.zero
+                subview.isSizeRoughlyEqualTo(rect) && rect.size != CGSize.zero
         }
     }
     

--- a/UnIt_SampleApp/UnIt_SampleAppTests/CGFloat+PrecisionSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/CGFloat+PrecisionSpec.swift
@@ -17,13 +17,13 @@ class CGFloatPrecisionSpec: QuickSpec {
                 expect(roundedNumber).to(equal(CGFloat(235)))
             }
             
-            it("should round 14.64323 down to 14.64 when two decimal places is specified") {
+            it("should round 14.644932 down to 14.64 when high degree of precision is specified") {
                 number = CGFloat(14.644932)
                 let roundedNumber = number.roundTo(decimalPlace: 2)
                 expect(roundedNumber).to(equal(CGFloat(14.64)))
             }
             
-            it("should round 14.645 up to 14.65 when two decimal places is specified") {
+            it("should round 14.645 up to 14.65 when high degree of precision is specified") {
                 number = CGFloat(14.645)
                 let roundedNumber = number.roundTo(decimalPlace: 2)
                 expect(roundedNumber).to(equal(CGFloat(14.65)))

--- a/UnIt_SampleApp/UnIt_SampleAppTests/CGFloat+PrecisionSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/CGFloat+PrecisionSpec.swift
@@ -1,1 +1,33 @@
+import Nimble
+import Quick
+import UnIt
+@testable import UnIt_SampleApp
 
+class CGFloatPrecisionSpec: QuickSpec {
+    override func spec() {
+        var number: CGFloat!
+        
+        describe("Rounding") {
+            beforeEach {
+                number = nil
+            }
+            it("should round 234.865 up to 235 when zero decimal places is specified") {
+                number = CGFloat(234.865)
+                let roundedNumber = number.roundTo(decimalPlace: 0)
+                expect(roundedNumber).to(equal(CGFloat(235)))
+            }
+            
+            it("should round 14.64323 down to 14.64 when two decimal places is specified") {
+                number = CGFloat(14.644932)
+                let roundedNumber = number.roundTo(decimalPlace: 2)
+                expect(roundedNumber).to(equal(CGFloat(14.64)))
+            }
+            
+            it("should round 14.645 up to 14.65 when two decimal places is specified") {
+                number = CGFloat(14.645)
+                let roundedNumber = number.roundTo(decimalPlace: 2)
+                expect(roundedNumber).to(equal(CGFloat(14.65)))
+            }
+        }
+    }
+}

--- a/UnIt_SampleApp/UnIt_SampleAppTests/CGSize+ComparingSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/CGSize+ComparingSpec.swift
@@ -32,5 +32,4 @@ class CGSizeComparingSpec: QuickSpec {
             }
         }
     }
-    
 }

--- a/UnIt_SampleApp/UnIt_SampleAppTests/CGSize+ComparingSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/CGSize+ComparingSpec.swift
@@ -18,6 +18,19 @@ class CGSizeComparingSpec: QuickSpec {
                 otherSize = CGSize(width: 200.54, height: 12.923509)
                 expect(size.isEqualTo(otherSize: otherSize, precision: 2)).to(be(true))
             }
+            
+            it("should return true if other size is the same width and height, when zero decimal places is specified") {
+                size = CGSize(width: 200.54, height: 12.923509)
+                otherSize = CGSize(width: 200.54, height: 12.923509)
+                expect(size.isEqualTo(otherSize: otherSize, precision: 0)).to(be(true))
+            }
+            
+            it("should return true if it and the other size are of zero width and height, when two decimal places is specified") {
+                size = CGSize(width: 0, height: 0)
+                otherSize = CGSize(width: 0, height: 0)
+                expect(size.isEqualTo(otherSize: otherSize, precision: 2)).to(be(true))
+            }
         }
     }
+    
 }

--- a/UnIt_SampleApp/UnIt_SampleAppTests/CGSize+ComparingSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/CGSize+ComparingSpec.swift
@@ -5,30 +5,42 @@ import UnIt
 
 class CGSizeComparingSpec: QuickSpec {
     override func spec() {
-        var size: CGSize!
-        var otherSize: CGSize!
-        
-        describe("Comparing this size to other size") {
+        fdescribe("Comparing this size to other size") {
+            var size: CGSize!
+            var otherSize: CGSize!
+            
             beforeEach {
                 size = nil
                 otherSize = nil
             }
-            it("should return true if other size is the same width and height, when two decimal places is specified") {
+            it("should return true if other size is the same width and height, when high degree of precision is specified") {
                 size = CGSize(width: 200.54, height: 12.923509)
                 otherSize = CGSize(width: 200.54, height: 12.923509)
-                expect(size.isEqualTo(otherSize: otherSize, precision: 2)).to(be(true))
+                expect(size.isRoughlyEqualTo(otherSize: otherSize, precision: 2)).to(beTruthy())
             }
             
             it("should return true if other size is the same width and height, when zero decimal places is specified") {
                 size = CGSize(width: 200.54, height: 12.923509)
                 otherSize = CGSize(width: 200.54, height: 12.923509)
-                expect(size.isEqualTo(otherSize: otherSize, precision: 0)).to(be(true))
+                expect(size.isRoughlyEqualTo(otherSize: otherSize, precision: 0)).to(beTruthy())
             }
             
-            it("should return true if it and the other size are of zero width and height, when two decimal places is specified") {
+            it("should be able to match zero sizes, when high degree of precision is specified") {
                 size = CGSize(width: 0, height: 0)
                 otherSize = CGSize(width: 0, height: 0)
-                expect(size.isEqualTo(otherSize: otherSize, precision: 2)).to(be(true))
+                expect(size.isRoughlyEqualTo(otherSize: otherSize, precision: 2)).to(beTruthy())
+            }
+            
+            it("should be able to match zero widths and zero heights, when high degree of precision is specified") {
+                size = CGSize(width: 0, height: 423.43)
+                otherSize = CGSize(width: 0, height: 423.43)
+                expect(size.isRoughlyEqualTo(otherSize: otherSize, precision: 2)).to(beTruthy())
+            }
+            
+            it("should be able to match non-zero widths and zero heights, when high degree of precision is specified") {
+                size = CGSize(width: 423.43, height: 0)
+                otherSize = CGSize(width: 423.43, height: 0)
+                expect(size.isRoughlyEqualTo(otherSize: otherSize, precision: 2)).to(beTruthy())
             }
         }
     }

--- a/UnIt_SampleApp/UnIt_SampleAppTests/CGSize+ComparingSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/CGSize+ComparingSpec.swift
@@ -1,1 +1,23 @@
+import Nimble
+import Quick
+import UnIt
+@testable import UnIt_SampleApp
 
+class CGSizeComparingSpec: QuickSpec {
+    override func spec() {
+        var size: CGSize!
+        var otherSize: CGSize!
+        
+        describe("Comparing this size to other size") {
+            beforeEach {
+                size = nil
+                otherSize = nil
+            }
+            it("should return true if other size is the same width and height, when two decimal places is specified") {
+                size = CGSize(width: 200.54, height: 12.923509)
+                otherSize = CGSize(width: 200.54, height: 12.923509)
+                expect(size.isEqualTo(otherSize: otherSize, precision: 2)).to(be(true))
+            }
+        }
+    }
+}

--- a/UnIt_SampleApp/UnIt_SampleAppTests/CGSize+ComparingSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/CGSize+ComparingSpec.swift
@@ -19,9 +19,9 @@ class CGSizeComparingSpec: QuickSpec {
                 expect(size.isRoughlyEqualTo(otherSize: otherSize, precision: 2)).to(beTruthy())
             }
             
-            it("should return true if other size is the same width and height, when zero decimal places is specified") {
-                size = CGSize(width: 200.54, height: 12.923509)
-                otherSize = CGSize(width: 200.54, height: 12.923509)
+            it("should return true if other size is the same width and height, when low precision is specified") {
+                size = CGSize(width: 200, height: 12)
+                otherSize = CGSize(width: 200, height: 12)
                 expect(size.isRoughlyEqualTo(otherSize: otherSize, precision: 0)).to(beTruthy())
             }
             

--- a/UnIt_SampleApp/UnIt_SampleAppTests/CGSize+ComparingSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/CGSize+ComparingSpec.swift
@@ -5,7 +5,7 @@ import UnIt
 
 class CGSizeComparingSpec: QuickSpec {
     override func spec() {
-        fdescribe("Comparing this size to other size") {
+        describe("Comparing this size to other size") {
             var size: CGSize!
             var otherSize: CGSize!
             
@@ -25,15 +25,19 @@ class CGSizeComparingSpec: QuickSpec {
                 expect(size.isRoughlyEqualTo(otherSize: otherSize, precision: 0)).to(beTruthy())
             }
             
-            it("should be able to match zero sizes, when high degree of precision is specified") {
-                size = CGSize(width: 0, height: 0)
-                otherSize = CGSize(width: 0, height: 0)
+            it("should be able to match zero sizes") {
+                expect(CGSize.zero.isRoughlyEqualTo(otherSize: CGSize(width: 0, height: 0), precision: 2)).to(beTruthy())
+            }
+            
+            it("should be able to match zero widths") {
+                size = CGSize(width: 0, height: 423.43)
+                otherSize = CGSize(width: 0, height: 423.43)
                 expect(size.isRoughlyEqualTo(otherSize: otherSize, precision: 2)).to(beTruthy())
             }
             
-            it("should be able to match zero widths and zero heights, when high degree of precision is specified") {
-                size = CGSize(width: 0, height: 423.43)
-                otherSize = CGSize(width: 0, height: 423.43)
+            it("should be able to match zero heights") {
+                size = CGSize(width: 2423.34, height: 0)
+                otherSize = CGSize(width: 2423.34, height: 0)
                 expect(size.isRoughlyEqualTo(otherSize: otherSize, precision: 2)).to(beTruthy())
             }
             

--- a/UnIt_SampleApp/UnIt_SampleAppTests/DeviceSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/DeviceSpec.swift
@@ -10,7 +10,7 @@ class DeviceSpec: QuickSpec {
         var subjectScaleFactor: CGFloat!
         var loadedVc: NibViewController!
         
-        fdescribe("Loading a view controller") {
+        describe("Loading a view controller") {
             beforeEach {
                 subject = nil
                 subjectFrame = nil

--- a/UnIt_SampleApp/UnIt_SampleAppTests/DeviceSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/DeviceSpec.swift
@@ -5,81 +5,61 @@ import UnIt
 
 class DeviceSpec: QuickSpec {
     override func spec() {
-        var subject: Device!
-        var subjectFrame: CGSize!
-        var subjectScaleFactor: CGFloat!
-        var loadedVc: NibViewController!
         
-        describe("Loading a view controller") {
+        fdescribe("Accessing the dimensions of the device") {
+            var subject: Device!
+            
             beforeEach {
                 subject = nil
-                subjectFrame = nil
-                subjectScaleFactor =  nil
-                loadedVc = nil
             }
             
-            it("should have the root view's frame's size equal to the iPhoneSE's screensize, and root view's contentScaleFactor equal to the iPhoneSE's scaleFactor") {
+            it("should return the correct tuple consisting of size and scale factor for iPhoneSE") {
                 subject = .iPhoneSE
-                subjectFrame = subject.dimensions.screensize
-                subjectScaleFactor = subject.dimensions.scaleFactor
-                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
-                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
-                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 320, height: 568)))
+                expect(dimensions.scaleFactor).to(equal(2.0))
             }
             
-            it("should have the root view's frame's size equal to the iPhone6 screensize, and root view's contentScaleFactor equal to the iPhone6 scaleFactor") {
+            it("should return the correct tuple consisting of size and scale factor for iPhone6") {
                 subject = .iPhone6
-                subjectFrame = subject.dimensions.screensize
-                subjectScaleFactor = subject.dimensions.scaleFactor
-                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
-                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
-                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 375, height: 667)))
+                expect(dimensions.scaleFactor).to(equal(2.0))
             }
             
-            it("should have the root view's frame's size equal to the iPhone6Plus' screensize, and root view's contentScaleFactor equal to the iPhone6Plus' scaleFactor") {
+            it("should return the correct tuple consisting of size and scale factor for iPhone6Plus") {
                 subject = .iPhone6Plus
-                subjectFrame = subject.dimensions.screensize
-                subjectScaleFactor = subject.dimensions.scaleFactor
-                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
-                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
-                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 375, height: 667)))
+                expect(dimensions.scaleFactor).to(equal(3.0))
             }
             
-            it("should have the root view's frame's size equal to the iPhone7Plus' screensize, and root view's contentScaleFactor equal to the iPhone7Plus' scaleFactor") {
+            it("should return the correct tuple consisting of size and scale factor for iPhone7Plus") {
                 subject = .iPhone7Plus
-                subjectFrame = subject.dimensions.screensize
-                subjectScaleFactor = subject.dimensions.scaleFactor
-                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
-                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
-                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 414, height: 736)))
+                expect(dimensions.scaleFactor).to(equal(3.0))
             }
             
-            it("should have the root view's frame's size equal to the iPhoneX's screensize, and root view's contentScaleFactor equal to the iPhoneX's scaleFactor") {
+            it("should return the correct tuple consisting of size and scale factor for iPhoneX") {
                 subject = .iPhoneX
-                subjectFrame = subject.dimensions.screensize
-                subjectScaleFactor = subject.dimensions.scaleFactor
-                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
-                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
-                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
-
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 375, height: 812)))
+                expect(dimensions.scaleFactor).to(equal(3.0))
             }
             
-            it("should have the root view's frame's size equal to the iPhoneXR's screensize, and root view's contentScaleFactor equal to the iPhoneXR's scaleFactor") {
+            it("should return the correct tuple consisting of size and scale factor for iPhoneXR") {
                 subject = .iPhoneXR
-                subjectFrame = subject.dimensions.screensize
-                subjectScaleFactor = subject.dimensions.scaleFactor
-                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
-                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
-                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 414, height: 896)))
+                expect(dimensions.scaleFactor).to(equal(2.0))
             }
             
-            it("should have the root view's frame's size equal to the iPhoneXSMax's screensize, and root view's contentScaleFactor equal to the iPhoneXSMax's scaleFactor") {
+            it("should return the correct tuple consisting of size and scale factor for iPhoneXSMax") {
                 subject = .iPhoneXSMax
-                subjectFrame = subject.dimensions.screensize
-                subjectScaleFactor = subject.dimensions.scaleFactor
-                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
-                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
-                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 414, height: 896)))
+                expect(dimensions.scaleFactor).to(equal(3.0))
             }
         }
     }

--- a/UnIt_SampleApp/UnIt_SampleAppTests/DeviceSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/DeviceSpec.swift
@@ -106,4 +106,3 @@ class DeviceSpec: QuickSpec {
         }
     }
 }
-

--- a/UnIt_SampleApp/UnIt_SampleAppTests/DeviceSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/DeviceSpec.swift
@@ -6,56 +6,98 @@ import UnIt
 class DeviceSpec: QuickSpec {
     override func spec() {
         
-        fdescribe("Accessing the dimensions of the device") {
+        describe("The dimensions of the device") {
             var subject: Device!
             
             beforeEach {
                 subject = nil
             }
             
-            it("should return the correct tuple consisting of size and scale factor for iPhoneSE") {
+            it("should be the size and scale factor of iPhoneSE") {
                 subject = .iPhoneSE
                 let dimensions = subject.dimensions
                 expect(dimensions.screensize).to(equal(CGSize(width: 320, height: 568)))
                 expect(dimensions.scaleFactor).to(equal(2.0))
             }
             
-            it("should return the correct tuple consisting of size and scale factor for iPhone6") {
+            it("should be the size and scale factor of iPhone6") {
                 subject = .iPhone6
                 let dimensions = subject.dimensions
                 expect(dimensions.screensize).to(equal(CGSize(width: 375, height: 667)))
                 expect(dimensions.scaleFactor).to(equal(2.0))
             }
             
-            it("should return the correct tuple consisting of size and scale factor for iPhone6Plus") {
+            it("should be the size and scale factor of iPhone6S") {
+                subject = .iPhone6S
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 375, height: 667)))
+                expect(dimensions.scaleFactor).to(equal(2.0))
+            }
+            
+            it("should be the size and scale factor of iPhone7") {
+                subject = .iPhone7
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 375, height: 667)))
+                expect(dimensions.scaleFactor).to(equal(2.0))
+            }
+            
+            it("should be the size and scale factor of iPhone8") {
+                subject = .iPhone8
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 375, height: 667)))
+                expect(dimensions.scaleFactor).to(equal(2.0))
+            }
+            
+            it("should be the size and scale factor of iPhone6Plus") {
                 subject = .iPhone6Plus
                 let dimensions = subject.dimensions
                 expect(dimensions.screensize).to(equal(CGSize(width: 375, height: 667)))
                 expect(dimensions.scaleFactor).to(equal(3.0))
             }
             
-            it("should return the correct tuple consisting of size and scale factor for iPhone7Plus") {
+            it("should be the size and scale factor of iPhone6SPlus") {
+                subject = .iPhone6SPlus
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 375, height: 667)))
+                expect(dimensions.scaleFactor).to(equal(3.0))
+            }
+            
+            it("should be the size and scale factor of iPhone7Plus") {
                 subject = .iPhone7Plus
                 let dimensions = subject.dimensions
                 expect(dimensions.screensize).to(equal(CGSize(width: 414, height: 736)))
                 expect(dimensions.scaleFactor).to(equal(3.0))
             }
             
-            it("should return the correct tuple consisting of size and scale factor for iPhoneX") {
+            it("should be the size and scale factor of iPhone8Plus") {
+                subject = .iPhone7Plus
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 414, height: 736)))
+                expect(dimensions.scaleFactor).to(equal(3.0))
+            }
+            
+            it("should be the size and scale factor of iPhoneX") {
                 subject = .iPhoneX
                 let dimensions = subject.dimensions
                 expect(dimensions.screensize).to(equal(CGSize(width: 375, height: 812)))
                 expect(dimensions.scaleFactor).to(equal(3.0))
             }
             
-            it("should return the correct tuple consisting of size and scale factor for iPhoneXR") {
+            it("should be the size and scale factor of iPhoneXS") {
+                subject = .iPhoneXS
+                let dimensions = subject.dimensions
+                expect(dimensions.screensize).to(equal(CGSize(width: 375, height: 812)))
+                expect(dimensions.scaleFactor).to(equal(3.0))
+            }
+            
+            it("should be the size and scale factor of iPhoneXR") {
                 subject = .iPhoneXR
                 let dimensions = subject.dimensions
                 expect(dimensions.screensize).to(equal(CGSize(width: 414, height: 896)))
                 expect(dimensions.scaleFactor).to(equal(2.0))
             }
             
-            it("should return the correct tuple consisting of size and scale factor for iPhoneXSMax") {
+            it("should be the size and scale factor of iPhoneXSMax") {
                 subject = .iPhoneXSMax
                 let dimensions = subject.dimensions
                 expect(dimensions.screensize).to(equal(CGSize(width: 414, height: 896)))

--- a/UnIt_SampleApp/UnIt_SampleAppTests/DeviceSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/DeviceSpec.swift
@@ -1,1 +1,87 @@
+import Nimble
+import Quick
+import UnIt
+@testable import UnIt_SampleApp
+
+class DeviceSpec: QuickSpec {
+    override func spec() {
+        var subject: Device!
+        var subjectFrame: CGSize!
+        var subjectScaleFactor: CGFloat!
+        var loadedVc: NibViewController!
+        
+        fdescribe("Loading a view controller") {
+            beforeEach {
+                subject = nil
+                subjectFrame = nil
+                subjectScaleFactor =  nil
+                loadedVc = nil
+            }
+            
+            it("should have the root view's frame's size equal to the iPhoneSE's screensize, and root view's contentScaleFactor equal to the iPhoneSE's scaleFactor") {
+                subject = .iPhoneSE
+                subjectFrame = subject.dimensions.screensize
+                subjectScaleFactor = subject.dimensions.scaleFactor
+                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
+                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
+                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+            }
+            
+            it("should have the root view's frame's size equal to the iPhone6 screensize, and root view's contentScaleFactor equal to the iPhone6 scaleFactor") {
+                subject = .iPhone6
+                subjectFrame = subject.dimensions.screensize
+                subjectScaleFactor = subject.dimensions.scaleFactor
+                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
+                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
+                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+            }
+            
+            it("should have the root view's frame's size equal to the iPhone6Plus' screensize, and root view's contentScaleFactor equal to the iPhone6Plus' scaleFactor") {
+                subject = .iPhone6Plus
+                subjectFrame = subject.dimensions.screensize
+                subjectScaleFactor = subject.dimensions.scaleFactor
+                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
+                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
+                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+            }
+            
+            it("should have the root view's frame's size equal to the iPhone7Plus' screensize, and root view's contentScaleFactor equal to the iPhone7Plus' scaleFactor") {
+                subject = .iPhone7Plus
+                subjectFrame = subject.dimensions.screensize
+                subjectScaleFactor = subject.dimensions.scaleFactor
+                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
+                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
+                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+            }
+            
+            it("should have the root view's frame's size equal to the iPhoneX's screensize, and root view's contentScaleFactor equal to the iPhoneX's scaleFactor") {
+                subject = .iPhoneX
+                subjectFrame = subject.dimensions.screensize
+                subjectScaleFactor = subject.dimensions.scaleFactor
+                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
+                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
+                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+
+            }
+            
+            it("should have the root view's frame's size equal to the iPhoneXR's screensize, and root view's contentScaleFactor equal to the iPhoneXR's scaleFactor") {
+                subject = .iPhoneXR
+                subjectFrame = subject.dimensions.screensize
+                subjectScaleFactor = subject.dimensions.scaleFactor
+                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
+                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
+                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+            }
+            
+            it("should have the root view's frame's size equal to the iPhoneXSMax's screensize, and root view's contentScaleFactor equal to the iPhoneXSMax's scaleFactor") {
+                subject = .iPhoneXSMax
+                subjectFrame = subject.dimensions.screensize
+                subjectScaleFactor = subject.dimensions.scaleFactor
+                loadedVc = ViewController.loadAndSetupViewControllerFromNib(String(describing: NibViewController.self), NibViewController.self, subject)
+                expect(loadedVc.view.frame.size).to(equal(subjectFrame))
+                expect(loadedVc.view.contentScaleFactor).to(equal(subjectScaleFactor))
+            }
+        }
+    }
+}
 

--- a/UnIt_SampleApp/UnIt_SampleAppTests/UIView+InspectingSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/UIView+InspectingSpec.swift
@@ -5,17 +5,120 @@ import UnIt
 
 class UIViewInspectingSpec: QuickSpec {
     override func spec() {
-        var loadedVc: ActionViewController!
+        var view: UIView!
         
-        describe("ViewController with user inputs") {
+        describe("This view") {
             beforeEach() {
-                loadedVc = UIViewController.loadAndSetupViewControllerFromNib("ActionViewController", ActionViewController.self, Device.iPhone7Plus)
+                view = nil
             }
             
-            it("should have 3 hidden buttons") {
-                expect(loadedVc.firstHiddenButton.isTrulyVisible).to(beFalse())
-                expect(loadedVc.secondHiddenButton.isTrulyVisible).to(beFalse())
-                expect(loadedVc.buttonInHiddenView.isTrulyVisible).to(beFalse())
+            it("should be truly visible") {
+                view  = UIView(frame: CGRect(x: 43.542, y: 12, width: 343.34, height: 534.32))
+                expect(view.isTrulyVisible).to(beTruthy())
+            }
+            
+            it("should not be truly visible given that its superview is not truly visible, even though it itself is") {
+                view  = UIView(frame: CGRect(x: 43.542, y: 12, width: 343.34, height: 534.32))
+                expect(view.isTrulyVisible).to(beTruthy())
+
+                let superview = UIView(frame: CGRect(x: 43.542, y: 12, width: 0, height: 777))
+                superview.addSubview(view)
+                expect(view.isTrulyVisible).to(beFalsy())
+            }
+            
+            it("should not be truly visible if it is hidden") {
+                view  = UIView(frame: CGRect(x: 43.542, y: 12, width: 343.34, height: 534.32))
+                view.isHidden = true
+                expect(view.isTrulyVisible).to(beFalsy())
+            }
+            
+            it("should not be truly visible if its alpha is 0") {
+                view  = UIView(frame: CGRect(x: 43.542, y: 12, width: 343.34, height: 534.32))
+                view.alpha = 0
+                expect(view.isTrulyVisible).to(beFalsy())
+            }
+            
+            it("should not be truly visible if its width is 0") {
+                view  = UIView(frame: CGRect(x: 43.542, y: 12, width: 0, height: 534.32))
+                expect(view.isTrulyVisible).to(beFalsy())
+            }
+            
+            it("should not be truly visible if its height is 0") {
+                view  = UIView(frame: CGRect(x: 43.542, y: 12, width: 343.34, height: 0))
+                expect(view.isTrulyVisible).to(beFalsy())
+            }
+            
+            it("should not be truly visible if its height is 0") {
+                view  = UIView(frame: CGRect(x: 43.542, y: 12, width: 0, height: 0))
+                expect(view.isTrulyVisible).to(beFalsy())
+            }
+        }
+        
+        describe("Comparing this view to other view") {
+            var view: UIView!
+            var otherView: UIView!
+            
+            beforeEach {
+                view = nil
+                otherView = nil
+            }
+            
+            it("should return true if other view is the same width and height") {
+                view = UIView(frame: CGRect(x: 43.542, y: 12, width: 343.34, height: 534.32))
+                otherView = UIView(frame: CGRect(x: 43.542, y: 12, width: 343.34, height: 534.32))
+                expect(view.isSizeRoughlyEqualTo(otherView: otherView)).to(beTruthy())
+            }
+            
+            it("should be able to match view with zero height and width") {
+                view = UIView(frame: CGRect(x: 43.542, y: 12, width: 0, height: 0))
+                otherView = UIView(frame: CGRect(x: 43.542, y: 12, width: 0, height: 0))
+                expect(view.isSizeRoughlyEqualTo(otherView: otherView)).to(beTruthy())
+            }
+            
+            it("should be able to match views with 0 widths") {
+                view = UIView(frame: CGRect(x: 43.542, y: 12, width: 0, height: 534.32))
+                otherView = UIView(frame: CGRect(x: 43.542, y: 12, width: 0, height: 534.32))
+                expect(view.isSizeRoughlyEqualTo(otherView: otherView)).to(beTruthy())
+            }
+            
+            it("should be able to match views with 0 heights") {
+                view = UIView(frame: CGRect(x: 43.542, y: 12, width: 343.34, height: 0))
+                otherView = UIView(frame: CGRect(x: 43.542, y: 12, width: 343.34, height: 0))
+                expect(view.isSizeRoughlyEqualTo(otherView: otherView)).to(beTruthy())
+            }
+        }
+        
+        describe("Comparing this view to a rectangle") {
+            var view: UIView!
+            var otherRect: CGRect!
+            
+            beforeEach {
+                view = nil
+                otherRect = nil
+            }
+            
+            it("should return true if the rectangle is the same width and height") {
+                view = UIView(frame: CGRect(x: 43.542, y: 12, width: 343.34, height: 534.32))
+                otherRect = CGRect(x: 43.542, y: 12, width: 343.34, height: 534.32)
+                expect(view.isSizeRoughlyEqualTo(rect: otherRect)).to(beTruthy())
+            }
+            
+            it("should be able to match rectangle with zero height and width") {
+                view = UIView(frame: CGRect(x: 43.542, y: 12, width: 0, height: 0))
+                otherRect = CGRect(x: 43.542, y: 12, width: 0, height: 0)
+                expect(view.isSizeRoughlyEqualTo(rect: otherRect)).to(beTruthy())
+            }
+            
+            it("should be able to match rectangle with 0 width") {
+                view = UIView(frame: CGRect(x: 43.542, y: 12, width: 0, height: 534.32))
+                otherRect = CGRect(x: 43.542, y: 12, width: 0, height: 534.32)
+                expect(view.isSizeRoughlyEqualTo(rect: otherRect)).to(beTruthy())
+            }
+            
+            it("should be able to match rectangle with 0 height") {
+                view = UIView(frame: CGRect(x: 43.542, y: 12, width: 343.34, height: 0))
+                otherRect = CGRect(x: 43.542, y: 12, width: 343.34, height: 0)
+                expect(view.isSizeRoughlyEqualTo(rect: otherRect)).to(beTruthy())
             }
         }
     }


### PR DESCRIPTION
uiview-inspecting branch is a sub-branch off of device-CGFloat-CGSize-tests. This was a mistake. It should have been off of master. So, the diff will include changes made in device-CGFloat-CGSize-tests thus far as well. The last commit `
Add tests for UIView+Inspecting.` is where most of the `UIView+Inspecting` work lies, so please focus on that.