### PR TITLE
Remove XCTFail and check for thrown errors on UIControl+UserInteracting #30

### DIFF
--- a/UnIt/Source/UIControl+UserInteracting.swift
+++ b/UnIt/Source/UIControl+UserInteracting.swift
@@ -1,25 +1,27 @@
 import XCTest
 
+public enum UIControlUserInteractingError: Error {
+    case controlIsHidden
+    case controlIsDisabled
+    case controlHasZeroDimension
+}
+
 public extension UIControl {
     /**
      Simulates tapping on a **UIControl**. This works on **UIButton**, **UITableViewCell**, **UICollectionViewCell** and more.
      */
-    func tap() {
+    func tap() throws {
         if (isHidden) {
-            XCTFail("Control cannot be hidden.")
-            return
+            throw UIControlUserInteractingError.controlIsHidden
         }
         if (!isEnabled) {
-            XCTFail("Control cannot be disabled.")
-            return
+            throw UIControlUserInteractingError.controlIsDisabled
         }
         if (bounds.size.width == 0) {
-            XCTFail("Control cannot have width of 0.")
-            return
+            throw UIControlUserInteractingError.controlHasZeroDimension
         }
         if (bounds.size.height == 0) {
-            XCTFail("Control cannot have height of 0.")
-            return
+            throw UIControlUserInteractingError.controlHasZeroDimension
         }
         sendActions(for: .touchUpInside)
     }

--- a/UnIt_SampleApp/UnIt_SampleApp/ViewControllers/ActionViewController.swift
+++ b/UnIt_SampleApp/UnIt_SampleApp/ViewControllers/ActionViewController.swift
@@ -14,6 +14,7 @@ class ActionViewController: UIViewController {
     @IBOutlet weak var secondHiddenButton: UIButton!
     @IBOutlet weak var hiddenViewThatContainsButton: UIView!
     @IBOutlet weak var buttonInHiddenView: UIButton!
+    @IBOutlet weak var zeroWidthButton: UIButton!
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/UnIt_SampleApp/UnIt_SampleApp/ViewControllers/ActionViewController.xib
+++ b/UnIt_SampleApp/UnIt_SampleApp/ViewControllers/ActionViewController.xib
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14854.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14806.4"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ActionViewController" customModule="PieceOfCake_SampleApp" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ActionViewController" customModule="UnIt_SampleApp" customModuleProvider="target">
             <connections>
                 <outlet property="button" destination="Rhn-Ky-aUy" id="VWu-sj-Ry3"/>
                 <outlet property="buttonInHiddenView" destination="ayn-I2-uNh" id="KdX-jA-T2f"/>
@@ -23,6 +21,7 @@
                 <outlet property="textField" destination="P8N-lQ-4OL" id="oXb-aH-ck5"/>
                 <outlet property="textFieldSwitch" destination="q3l-bB-3tx" id="i7v-NE-P2B"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="zeroWidthButton" destination="7ub-A6-4LL" id="c18-of-MNe"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -31,7 +30,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="P8N-lQ-4OL">
-                    <rect key="frame" x="10" y="55" width="296" height="30"/>
+                    <rect key="frame" x="10" y="35" width="296" height="34"/>
                     <nil key="textColor"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <textInputTraits key="textInputTraits"/>
@@ -40,37 +39,37 @@
                     </connections>
                 </textField>
                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="q3l-bB-3tx">
-                    <rect key="frame" x="316" y="54.5" width="51" height="31"/>
+                    <rect key="frame" x="316" y="36.5" width="51" height="31"/>
                 </switch>
                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="PdU-iU-b4b">
-                    <rect key="frame" x="316" y="105.5" width="51" height="31"/>
+                    <rect key="frame" x="316" y="87.5" width="51" height="31"/>
                 </switch>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rhn-Ky-aUy">
-                    <rect key="frame" x="10" y="106" width="166" height="30"/>
+                    <rect key="frame" x="10" y="88" width="166" height="30"/>
                     <state key="normal" title="Tap me to enable switch"/>
                     <connections>
                         <action selector="buttonTapped:" destination="-1" eventType="touchUpInside" id="q4R-2F-WcR"/>
                     </connections>
                 </button>
                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8Nl-yd-vkS">
-                    <rect key="frame" x="10" y="157" width="296" height="30"/>
+                    <rect key="frame" x="10" y="137" width="296" height="34"/>
                     <nil key="textColor"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <textInputTraits key="textInputTraits"/>
                 </textField>
                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="YTl-DU-DRx">
-                    <rect key="frame" x="316" y="156.5" width="51" height="31"/>
+                    <rect key="frame" x="316" y="138.5" width="51" height="31"/>
                 </switch>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j0F-22-xVn" userLabel="First Hidden Button">
-                    <rect key="frame" x="10" y="197" width="121.5" height="30"/>
+                    <rect key="frame" x="10" y="181" width="121.5" height="30"/>
                     <state key="normal" title="Button"/>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mDa-Zl-0iW" userLabel="Second Hidden Button">
-                    <rect key="frame" x="131.5" y="197" width="122" height="30"/>
+                    <rect key="frame" x="131.5" y="181" width="122" height="30"/>
                     <state key="normal" title="Button"/>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dfe-4G-pUd" userLabel="Hidden View that contains Button">
-                    <rect key="frame" x="253.5" y="197" width="121.5" height="30"/>
+                    <rect key="frame" x="253.5" y="181" width="121.5" height="30"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ayn-I2-uNh">
                             <rect key="frame" x="0.0" y="0.0" width="111.5" height="30"/>
@@ -85,6 +84,17 @@
                         <constraint firstItem="ayn-I2-uNh" firstAttribute="leading" secondItem="Dfe-4G-pUd" secondAttribute="leading" id="dtt-GT-u4t"/>
                     </constraints>
                 </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7ub-A6-4LL">
+                    <rect key="frame" x="184" y="88" width="0.0" height="30"/>
+                    <constraints>
+                        <constraint firstAttribute="width" id="Jz5-CV-rzj"/>
+                        <constraint firstAttribute="height" constant="30" id="kxO-zt-IdY"/>
+                    </constraints>
+                    <state key="normal" title="Zero width"/>
+                    <connections>
+                        <action selector="buttonTapped:" destination="-1" eventType="touchUpInside" id="Tp8-sJ-mXR"/>
+                    </connections>
+                </button>
             </subviews>
             <color key="backgroundColor" red="1" green="0.96496323699999997" blue="0.70793627830000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
@@ -93,6 +103,7 @@
                 <constraint firstItem="8Nl-yd-vkS" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="DMd-DH-WFG"/>
                 <constraint firstItem="Dfe-4G-pUd" firstAttribute="top" secondItem="mDa-Zl-0iW" secondAttribute="top" id="DjH-yj-4st"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Dfe-4G-pUd" secondAttribute="trailing" id="G2o-vW-ZgN"/>
+                <constraint firstItem="7ub-A6-4LL" firstAttribute="centerY" secondItem="Rhn-Ky-aUy" secondAttribute="centerY" id="GiD-Ws-HnM"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="q3l-bB-3tx" secondAttribute="trailing" constant="10" id="I9s-4d-SpE"/>
                 <constraint firstItem="mDa-Zl-0iW" firstAttribute="leading" secondItem="j0F-22-xVn" secondAttribute="trailing" id="IHM-X4-4QR"/>
                 <constraint firstItem="j0F-22-xVn" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="Pb6-ro-ofB"/>
@@ -100,6 +111,7 @@
                 <constraint firstItem="q3l-bB-3tx" firstAttribute="leading" secondItem="P8N-lQ-4OL" secondAttribute="trailing" constant="10" id="SEq-E7-AOd"/>
                 <constraint firstItem="Rhn-Ky-aUy" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="UkB-Kv-eeC"/>
                 <constraint firstItem="Rhn-Ky-aUy" firstAttribute="centerY" secondItem="PdU-iU-b4b" secondAttribute="centerY" id="VS5-Kf-Ni7"/>
+                <constraint firstItem="7ub-A6-4LL" firstAttribute="leading" secondItem="Rhn-Ky-aUy" secondAttribute="trailing" constant="8" symbolic="YES" id="XfM-lY-nXi"/>
                 <constraint firstItem="Dfe-4G-pUd" firstAttribute="leading" secondItem="mDa-Zl-0iW" secondAttribute="trailing" id="auO-na-ALG"/>
                 <constraint firstItem="Dfe-4G-pUd" firstAttribute="width" secondItem="j0F-22-xVn" secondAttribute="width" id="cLv-hA-V6j"/>
                 <constraint firstItem="YTl-DU-DRx" firstAttribute="leading" secondItem="8Nl-yd-vkS" secondAttribute="trailing" constant="10" id="cSe-Uz-skk"/>

--- a/UnIt_SampleApp/UnIt_SampleAppTests/UIControl+UserInteractingSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/UIControl+UserInteractingSpec.swift
@@ -10,19 +10,37 @@ class UIControlUserInteractingSpec: QuickSpec {
         describe("ViewController with user inputs") {
             beforeEach() {
                 loadedVc = UIViewController.loadAndSetupViewControllerFromNib("ActionViewController", ActionViewController.self, Device.iPhone7Plus)
+                loadedVc.buttonSwitch.isOn = false
+                loadedVc.button.isEnabled = true
+                loadedVc.button.isHidden = false
             }
             
-            context("When the user taps the action button - simulating the user tapping a button") {
-                beforeEach {
-                    loadedVc.buttonSwitch.isOn = false
-                    loadedVc.button.tap()
-                }
-                
-                it("should enable the button switch") {
+            context("When a tap is sent to the enabled and visible button") {
+                it("should toggle the corresponding switch") {
+                    expect { try loadedVc.button.tap() }.toNot(throwError())
                     expect(loadedVc.buttonSwitch.isOn).to(beTrue())
+                }
+            }
+            
+            context("When a tap is sent to a disabled button") {
+                it("should throw") {
+                    loadedVc.button.isEnabled = false
+                    expect { try loadedVc.button.tap() }.to(throwError())
+                }
+            }
+            
+            context("When a tap is sent to a hidden button") {
+                it("should throw") {
+                    loadedVc.button.isHidden = true
+                    expect { try loadedVc.button.tap() }.to(throwError())
+                }
+            }
+            
+            context("When a tap is sent to a zero-width button") {
+                it("should throw") {
+                    expect { try loadedVc.zeroWidthButton.tap() }.to(throwError())
                 }
             }
         }
     }
 }
-


### PR DESCRIPTION
Removed XCTFail from UnIt since it prevented testing the failure conditions of the tap() function.
Added a zero-width button to test that failure condition.