### PR TITLE
Add functionality and test for label going multiline [44]

### DIFF
--- a/UnIt/Source/UILabel+Inspecting.swift
+++ b/UnIt/Source/UILabel+Inspecting.swift
@@ -11,10 +11,18 @@ public extension UILabel {
     }
     
     /**
-     Check to see if a line is currently truncated based on its size and font.
+     Check to see if the text is currently truncated based on its size and font.
      - Returns: A true/false value on whether the label is truncated.
      */
     var isTruncated: Bool {
         return numberOfTheoreticalLines() > numberOfLines && numberOfLines != 0
+    }
+    
+    /**
+     Check to see if the text has gone past single-line on a label with no maximum.
+     - Returns: A true/false value on whether the label is multilined.
+     */
+    var isMultilined: Bool {
+        return numberOfTheoreticalLines() > 1 && numberOfLines == 0
     }
 }

--- a/UnIt_SampleApp/UnIt_SampleApp/ViewControllers/LabelViewController.swift
+++ b/UnIt_SampleApp/UnIt_SampleApp/ViewControllers/LabelViewController.swift
@@ -8,6 +8,7 @@ class LabelViewController: UIViewController {
     @IBOutlet weak var oneLineLabelThatSizeWillDecreaseToTruncate: UILabel!
     @IBOutlet weak var widthConstraintForDecreaseSizeLabel: NSLayoutConstraint!
     @IBOutlet weak var threeLineLabelWithTruncation: UILabel!
+    @IBOutlet weak var shortInfiniteLabel: UILabel!
     @IBOutlet weak var infiniteLineLabel: UILabel!
     
     override func viewDidLoad() {

--- a/UnIt_SampleApp/UnIt_SampleApp/ViewControllers/LabelViewController.xib
+++ b/UnIt_SampleApp/UnIt_SampleApp/ViewControllers/LabelViewController.xib
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14854.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14806.4"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LabelViewController" customModule="PieceOfCake_SampleApp" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LabelViewController" customModule="UnIt_SampleApp" customModuleProvider="target">
             <connections>
-                <outlet property="infiniteLineLabel" destination="iTk-6t-etj" id="Qwx-cc-qt7"/>
+                <outlet property="infiniteLineLabel" destination="TRe-dI-MG0" id="D1d-mk-HVv"/>
                 <outlet property="oneLineLabelNoTruncation" destination="wX5-6K-39k" id="nLb-j6-mUf"/>
                 <outlet property="oneLineLabelThatSizeWillDecreaseToTruncate" destination="KQD-l0-YdK" id="TAJ-7a-Cuo"/>
                 <outlet property="oneLineLabelWithIncreasingFontToTruncate" destination="Zsy-Fs-nV8" id="A1r-3E-Zqi"/>
                 <outlet property="oneLineLabelWithTruncation" destination="LAh-4h-oR6" id="qOB-9y-fNl"/>
+                <outlet property="shortInfiniteLabel" destination="iTk-6t-etj" id="yHT-Fg-tbr"/>
                 <outlet property="threeLineLabelWithTruncation" destination="Fus-O3-Iy2" id="V32-iX-3qG"/>
                 <outlet property="twoLineLabelNoTruncation" destination="pum-2J-NE3" id="g0W-tR-X7W"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
@@ -29,44 +28,50 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is a label that is not truncated, but close." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wX5-6K-39k">
-                    <rect key="frame" x="10" y="30" width="355" height="21"/>
+                    <rect key="frame" x="10" y="10" width="355" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This label is most definitely truncated. We'll just add a few more characters." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LAh-4h-oR6">
-                    <rect key="frame" x="10" y="61" width="355" height="21"/>
+                    <rect key="frame" x="10" y="41" width="355" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is a two line label. We are going to make sure that it does not truncate. " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pum-2J-NE3">
-                    <rect key="frame" x="10" y="92" width="355" height="41"/>
+                    <rect key="frame" x="10" y="72" width="355" height="41"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Not truncated yet, but we will increase font" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zsy-Fs-nV8">
-                    <rect key="frame" x="10" y="143" width="355" height="21"/>
+                    <rect key="frame" x="10" y="123" width="355" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Not truncated yet, but we will decrease size" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KQD-l0-YdK">
-                    <rect key="frame" x="10" y="174" width="355" height="21"/>
+                    <rect key="frame" x="10" y="154" width="355" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fus-O3-Iy2">
-                    <rect key="frame" x="10" y="205" width="355" height="61"/>
+                    <rect key="frame" x="10" y="185" width="355" height="61"/>
                     <string key="text">This is a 3 line label that is gonna be truncated. It's gonne be a lot of writing, so sit back and hold on tight! Almost there, kick back and relax. Any minute now. Is it now? I think so.</string>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This label has no end! We will add more text in viewDidAppear" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iTk-6t-etj">
-                    <rect key="frame" x="10" y="276" width="355" height="41"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This text is probably just one line on larger screens." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iTk-6t-etj">
+                    <rect key="frame" x="10" y="256" width="355" height="41"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="This label has no end! We will add more text in viewDidAppear" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TRe-dI-MG0">
+                    <rect key="frame" x="10" y="307" width="355" height="20.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -86,17 +91,21 @@
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="wX5-6K-39k" secondAttribute="trailing" constant="10" id="PQV-bu-fi8"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="iTk-6t-etj" secondAttribute="trailing" constant="10" id="Pq9-PB-awv"/>
                 <constraint firstItem="KQD-l0-YdK" firstAttribute="top" secondItem="Zsy-Fs-nV8" secondAttribute="bottom" constant="10" id="Vx9-Ej-own"/>
+                <constraint firstItem="iTk-6t-etj" firstAttribute="top" secondItem="Fus-O3-Iy2" secondAttribute="bottom" constant="10" id="YHM-nR-tvG"/>
                 <constraint firstItem="pum-2J-NE3" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="YT9-Wf-LqV"/>
-                <constraint firstItem="iTk-6t-etj" firstAttribute="top" secondItem="Fus-O3-Iy2" secondAttribute="bottom" constant="10" id="aBh-bH-dRA"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="iTk-6t-etj" secondAttribute="trailing" constant="10" id="g24-MO-702"/>
+                <constraint firstItem="iTk-6t-etj" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="gCb-1W-UVe"/>
                 <constraint firstItem="KQD-l0-YdK" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="kOA-GI-nxf"/>
                 <constraint firstItem="Fus-O3-Iy2" firstAttribute="top" secondItem="KQD-l0-YdK" secondAttribute="bottom" constant="10" id="mQk-uQ-PWu"/>
                 <constraint firstItem="wX5-6K-39k" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="nw3-HE-03U"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="pum-2J-NE3" secondAttribute="trailing" constant="10" id="nyr-fi-ggv"/>
                 <constraint firstItem="pum-2J-NE3" firstAttribute="top" secondItem="LAh-4h-oR6" secondAttribute="bottom" constant="10" id="pOR-KO-2gK"/>
                 <constraint firstItem="Fus-O3-Iy2" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="sHW-4r-fNj"/>
+                <constraint firstItem="TRe-dI-MG0" firstAttribute="top" secondItem="iTk-6t-etj" secondAttribute="bottom" constant="10" id="sl0-Mg-gYp"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Fus-O3-Iy2" secondAttribute="trailing" constant="10" id="vfU-lU-mmC"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="142" y="111"/>
         </view>
     </objects>
 </document>

--- a/UnIt_SampleApp/UnIt_SampleAppTests/UILabel+InspectingSpec.swift
+++ b/UnIt_SampleApp/UnIt_SampleAppTests/UILabel+InspectingSpec.swift
@@ -20,23 +20,23 @@ class UILabelInspectingSpec: QuickSpec {
             
             context("when the labels are set") {
                 it("should find the untruncated labels") {
-                    expect(loadedVc.oneLineLabelNoTruncation.isTruncated).to(equal(false))
-                    expect(loadedVc.twoLineLabelNoTruncation.isTruncated).to(equal(false))
-                    expect(loadedVc.infiniteLineLabel.isTruncated).to(equal(false))
+                    expect(loadedVc.oneLineLabelNoTruncation.isTruncated).to(beFalse())
+                    expect(loadedVc.twoLineLabelNoTruncation.isTruncated).to(beFalse())
+                    expect(loadedVc.infiniteLineLabel.isTruncated).to(beFalse())
                 }
                 
                 it("should find the truncated labels") {
-                    expect(loadedVc.oneLineLabelWithTruncation.isTruncated).to(equal(true))
-                    expect(loadedVc.oneLineLabelWithIncreasingFontToTruncate.isTruncated).to(equal(true))
-                    expect(loadedVc.oneLineLabelThatSizeWillDecreaseToTruncate.isTruncated).to(equal(true))
-                    expect(loadedVc.threeLineLabelWithTruncation.isTruncated).to(equal(true))
+                    expect(loadedVc.oneLineLabelWithTruncation.isTruncated).to(beTrue())
+                    expect(loadedVc.oneLineLabelWithIncreasingFontToTruncate.isTruncated).to(beTrue())
+                    expect(loadedVc.oneLineLabelThatSizeWillDecreaseToTruncate.isTruncated).to(beTrue())
+                    expect(loadedVc.threeLineLabelWithTruncation.isTruncated).to(beTrue())
                 }
                 
                 it("should determine the theoretical number of lines the label should have to look untruncated") {
                     expect(loadedVc.oneLineLabelNoTruncation.numberOfTheoreticalLines()).to(equal(1))
                     expect(loadedVc.oneLineLabelWithTruncation.numberOfTheoreticalLines()).to(equal(2))
                     expect(loadedVc.twoLineLabelNoTruncation.numberOfTheoreticalLines()).to(equal(2))
-                    expect(loadedVc.oneLineLabelWithIncreasingFontToTruncate.numberOfTheoreticalLines()).to(equal(3))
+                    expect(loadedVc.oneLineLabelWithIncreasingFontToTruncate.numberOfTheoreticalLines()).to(equal(2))
                     expect(loadedVc.oneLineLabelThatSizeWillDecreaseToTruncate.numberOfTheoreticalLines()).to(equal(2))
                     expect(loadedVc.threeLineLabelWithTruncation.numberOfTheoreticalLines()).to(equal(5))
                 }
@@ -50,7 +50,7 @@ class UILabelInspectingSpec: QuickSpec {
             
             context("when the labels are set") {
                 it("should determine the theoretical number of lines the label should have to look untruncated") {
-                    expect(loadedVc.threeLineLabelWithTruncation.numberOfTheoreticalLines()).to(equal(4)) // same as line 227
+                    expect(loadedVc.threeLineLabelWithTruncation.numberOfTheoreticalLines()).to(equal(4))
                 }
             }
         }
@@ -62,7 +62,25 @@ class UILabelInspectingSpec: QuickSpec {
             
             context("when the labels are set") {
                 it("should find the truncated labels") {
-                    expect(loadedVc.oneLineLabelNoTruncation.isTruncated).to(equal(true))
+                    expect(loadedVc.oneLineLabelNoTruncation.isTruncated).to(beTrue())
+                }
+            }
+        }
+        
+        describe("View Controller with a label that could be multilined") {
+            context("when the screen size allows one line") {
+                it("should not be multilined") {
+                    loadedVc = UIViewController.loadAndSetupViewControllerFromNib("LabelViewController", LabelViewController.self, Device.iPhoneXSMax)
+                    expect(loadedVc.shortInfiniteLabel.isMultilined).to(beFalse())
+                    expect(loadedVc.shortInfiniteLabel.numberOfTheoreticalLines()).to(equal(1))
+                }
+            }
+            
+            context("when the screen size forces multiline") {
+                it("should be multilined") {
+                    loadedVc = UIViewController.loadAndSetupViewControllerFromNib("LabelViewController", LabelViewController.self, Device.iPhoneSE)
+                    expect(loadedVc.shortInfiniteLabel.isMultilined).to(beTrue())
+                    expect(loadedVc.shortInfiniteLabel.numberOfTheoreticalLines()).to(equal(2))
                 }
             }
         }


### PR DESCRIPTION
Add a function to detect when an elastic label (lines == 0) has gone over one line, and add a test for this when changing device screen size.