### PR TITLE
Add an assertionFailure if the swizzled method can't be found anymore [43]

### DIFF
--- a/UnIt/Source/UIViewController+Constraints.swift
+++ b/UnIt/Source/UIViewController+Constraints.swift
@@ -51,6 +51,7 @@ extension UIView {
      */
     static let swizzleAutoLayoutAlertMethodOnce: Void = {
         guard let originalMethod = class_getInstanceMethod(UIView.self, NSSelectorFromString("engine:willBreakConstraint:dueToMutuallyExclusiveConstraints:")) else {
+            assertionFailure("Can't find a matching selector. Did the name change?")
             return
         }
         guard let swizzledMethod = class_getInstanceMethod(UIView.self, #selector(handleConstraintBreak(engine:breakConstraint:mutuallyExclusiveConstraints:))) else {

--- a/UnIt/Source/UIViewController+Constraints.swift
+++ b/UnIt/Source/UIViewController+Constraints.swift
@@ -51,7 +51,7 @@ extension UIView {
      */
     static let swizzleAutoLayoutAlertMethodOnce: Void = {
         guard let originalMethod = class_getInstanceMethod(UIView.self, NSSelectorFromString("engine:willBreakConstraint:dueToMutuallyExclusiveConstraints:")) else {
-            assertionFailure("Can't find a matching selector. Did the name change?")
+            assertionFailure("Swizzled selector for capturing constraints: 'engine:willBreakConstraint:dueToMutuallyExclusiveConstraints:' could not be found.")
             return
         }
         guard let swizzledMethod = class_getInstanceMethod(UIView.self, #selector(handleConstraintBreak(engine:breakConstraint:mutuallyExclusiveConstraints:))) else {


### PR DESCRIPTION
We can't throw any error from this code, so add an assertionFailure() to alert the user if the method signature changed.

(This was crashing my Xcode at home, but I think that was just an Xcode beta issue.)